### PR TITLE
Fix export of all day events without an end date.

### DIFF
--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
@@ -334,8 +334,11 @@ public class SaveCalendar extends RunnableWithProgress {
 
             if (end != null) {
                 dtEnd = new DtEnd(new Date(end));
-                l.add(dtEnd);
+            } else {
+                dtEnd = new DtEnd(utcDateFromMs(start.getTime() + DateUtils.DAY_IN_MILLIS));
             }
+
+            l.add(dtEnd);
         } else {
             // Regular or zero-time event. Start date must be a date-time
             Date startDate = getDateTime(cur, Events.DTSTART, Events.EVENT_TIMEZONE, cal);


### PR DESCRIPTION
I don't know why this would happen, but a user managed to encounter an
issue related to this.

This fix assumes that if there's no end date, we should assume it's one
day long.

This should fix #66. Requires the user to confirm it indeed fixes it before merging.