### PR TITLE
Newly generated UIDs on export are made persistent

### DIFF
--- a/CalendarImportExport/build.gradle
+++ b/CalendarImportExport/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         minSdkVersion 8

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
@@ -26,9 +26,11 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import net.fortuna.ical4j.data.CalendarOutputter;
@@ -51,7 +53,6 @@ import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.model.property.Organizer;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.Transp;
-import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.model.property.Version;
 import net.fortuna.ical4j.model.property.XProperty;
 import net.fortuna.ical4j.model.Period;
@@ -70,11 +71,15 @@ import org.sufficientlysecure.ical.util.Log;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.database.Cursor;
+import android.net.Uri;
 import android.os.Environment;
+import android.provider.CalendarContract;
 import android.provider.CalendarContractWrapper.Events;
 import android.provider.CalendarContractWrapper.Reminders;
 import android.text.format.DateUtils;
@@ -163,9 +168,13 @@ public class SaveCalendar extends RunnableWithProgress {
         }
 
         // query events
+        ContentResolver resolver = activity.getContentResolver();
+        int numberOfCreatedUids = 0;
+        if (Events.UID_2445 != null) {
+            numberOfCreatedUids  = ensureUids(activity, resolver, selectedCal);
+        }
         boolean relaxed = settings.getIcal4jValidationRelaxed();
         CompatibilityHints.setHintEnabled(CompatibilityHints.KEY_RELAXED_VALIDATION, relaxed);
-        ContentResolver resolver = activity.getContentResolver();
         List<VEvent> events = getEvents(resolver, selectedCal, cal);
 
         for (VEvent v: events)
@@ -175,7 +184,32 @@ public class SaveCalendar extends RunnableWithProgress {
 
         Resources res = activity.getResources();
         String msg = res.getQuantityString(R.plurals.wrote_n_events_to, events.size(), events.size(), file);
+        if (numberOfCreatedUids > 0) {
+            msg += "\n" + res.getQuantityString(R.plurals.created_n_uids_to, numberOfCreatedUids, numberOfCreatedUids);
+        }
         activity.showToast(msg);
+    }
+
+    private int ensureUids(MainActivity activity, ContentResolver resolver, AndroidCalendar cal) {
+        String[] cols = new String[] { Events._ID };
+        String[] args = new String[] { cal.mIdStr };
+        Map<Long, String> newUids = new HashMap<>();
+        Cursor cur = resolver.query(Events.CONTENT_URI, cols,
+                Events.CALENDAR_ID + " = ? AND " + Events.UID_2445 + " IS NULL", args, null);
+        while (cur.moveToNext()) {
+            Long id = getLong(cur, Events._ID);
+            String uid = activity.generateUid();
+            newUids.put(id, uid);
+        }
+        for (Long id: newUids.keySet()) {
+            String uid = newUids.get(id);
+            Uri updateUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id);
+            ContentValues c = new ContentValues();
+            c.put(Events.UID_2445, uid);
+            resolver.update(updateUri, c, null, null);
+            Log.i(TAG, "Generated UID " + uid + " for event " + id);
+        }
+        return newUids.size();
     }
 
     private List<VEvent> getEvents(ContentResolver resolver, AndroidCalendar cal_src, Calendar cal_dst) {
@@ -296,10 +330,7 @@ public class SaveCalendar extends RunnableWithProgress {
 
         PropertyList l = new PropertyList();
         l.add(timestamp);
-        if (copyProperty(l, Property.UID, cur, Events.UID_2445) == null) {
-            // Generate a UID. Not ideal, since its not reproducible
-            l.add(new Uid(getActivity().generateUid()));
-        }
+        copyProperty(l, Property.UID, cur, Events.UID_2445);
 
         String summary = copyProperty(l, Property.SUMMARY, cur, Events.TITLE);
         String description = copyProperty(l, Property.DESCRIPTION, cur, Events.DESCRIPTION);

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
@@ -471,12 +471,11 @@ public class MainActivity extends FragmentActivity implements View.OnClickListen
             mUidTail = uidPid + "@sufficientlysecure.org";
         }
 
-        long ms = System.currentTimeMillis();
-        if (mUidMs == ms)
-            ms++; // Force ms to be unique
+        mUidMs = Math.max(mUidMs, System.currentTimeMillis());
+        String uid = Long.toString(mUidMs) + mUidTail;
+        mUidMs++;
 
-        mUidMs = ms;
-        return Long.toString(ms) + mUidTail;
+        return uid;
     }
 
     @Override

--- a/CalendarImportExport/src/main/res/values/strings.xml
+++ b/CalendarImportExport/src/main/res/values/strings.xml
@@ -66,6 +66,10 @@
          <item quantity="one">Wrote %1$d event to %2$s</item>
          <item quantity="other">Wrote %1$d events to %2$s</item>
     </plurals>
+    <plurals name="created_n_uids_to">
+        <item quantity="one">Created %1$d fresh UID</item>
+        <item quantity="other">Created %1$d fresh UIDs</item>
+    </plurals>
 
     <!-- Must match the minutes array in RemindersDialog.java -->
     <string-array name="reminder_time_values">

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,18 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 
@@ -14,10 +14,6 @@ allprojects {
         jcenter()
         google()
     }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.3'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 15 19:24:05 CET 2018
+#Sat Apr 20 19:51:47 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 27 11:35:53 CEST 2017
+#Thu Nov 15 19:24:05 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
I am using calendar-import-export to have a purely local calendar solution over MTP only, with 3-way-merge of diverging calendars on my desktop and on my smartphone.

An issue in Android is that newly created calendar entries carry no UID for ical by default (I am using Etar on top of Offline Calendar). As I found it, calendar-import-export creates those ad-hoc: they are in the exported ical but with no backlink to the local calendar, which means that you can never re-import those in a valid way since they will always emerge as duplicates.

One solution is in this pull request: if UIDs have to be created, store them in the originating calendar entries.

The pull request is intended as a base for discussion and surely can be improved. One e. g. could argue that changing entries by just exporting them is not what a user expects; hence you could think about a setting which allows you to turn on and off that behaviour. Or to choose between not exporting entries with no UID at all or adding them on-the-fly.

I am  looking forward to your feedback.