### PR TITLE
Ignore deleted events (solves issue #44), support event colors

### DIFF
--- a/CalendarImportExport/build.gradle
+++ b/CalendarImportExport/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 57
-        versionName "2.6tw"
+        versionName "2.7tw"
     }
 
     dependencies {

--- a/CalendarImportExport/build.gradle
+++ b/CalendarImportExport/build.gradle
@@ -6,9 +6,9 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 26         /* App crashes on export when using v28 here!?! */
         versionCode 57
-        versionName "2.7tw"
+        versionName "2.72tw"
     }
 
     dependencies {

--- a/CalendarImportExport/build.gradle
+++ b/CalendarImportExport/build.gradle
@@ -1,23 +1,23 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '28.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 28
         versionCode 57
-        versionName "2.6"
+        versionName "2.6tw"
     }
 
     dependencies {
-        compile 'com.android.support:support-v4:23.3.0'
+        implementation 'com.android.support:support-v4:28.0.0'
 
-        compile 'org.mnode.ical4j:ical4j:1.0.6'
-        compile 'backport-util-concurrent:backport-util-concurrent:3.1'
-        compile 'commons-codec:commons-codec:1.10'
-        compile 'commons-lang:commons-lang:2.6'
+        implementation 'org.mnode.ical4j:ical4j:1.0.6'
+        implementation 'backport-util-concurrent:backport-util-concurrent:3.1'
+        implementation 'commons-codec:commons-codec:1.10'
+        implementation 'commons-lang:commons-lang:2.6'
     }
 
     compileOptions {

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/AndroidCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/AndroidCalendar.java
@@ -89,7 +89,7 @@ public class AndroidCalendar {
             calendar.mTimezone = getString(cur, Calendars.CALENDAR_TIME_ZONE);
 
             final String[] args = new String[] { calendar.mIdStr };
-            Cursor eventsCur = resolver.query(Events.CONTENT_URI, CAL_ID_COLS, CAL_ID_WHERE, args, null);
+            Cursor eventsCur = resolver.query(Events.CONTENT_URI, CAL_ID_COLS, CAL_ID_WHERE + " AND deleted=0", args, null);
             calendar.mNumEntries = eventsCur.getCount();
             eventsCur.close();
             calendars.add(calendar);

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ProcessVEvent.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ProcessVEvent.java
@@ -43,6 +43,7 @@ import net.fortuna.ical4j.model.Property;
 import org.sufficientlysecure.ical.ui.dialogs.RunnableWithProgress;
 import org.sufficientlysecure.ical.ui.MainActivity;
 import org.sufficientlysecure.ical.ui.RemindersDialog;
+import org.sufficientlysecure.ical.util.ColorUtils;
 import org.sufficientlysecure.ical.util.Log;
 
 import android.annotation.SuppressLint;
@@ -369,6 +370,25 @@ public class ProcessVEvent extends RunnableWithProgress {
             // Remove null/empty UIDs
             c.remove(Events.UID_2445);
         }
+
+        // set color values, if given in iCal
+        Property p = e.getProperty(SaveCalendar.X_COLORARGB);
+        if (p != null) {
+            // given RGB dominates color name
+            c.put(Events.EVENT_COLOR, Integer.toString(Integer.parseUnsignedInt(p.getValue(), 16)));
+        } else {
+            p = e.getProperty(SaveCalendar.EVENT_COLOR);
+            if (p != null) {
+                ColorUtils.ColorName color = ColorUtils.getColorFromName(p.getValue());
+                if (color != null) {
+                    c.put(Events.EVENT_COLOR, Integer.toString(0xff000000 | color.getRGB()));
+                }
+            } else {
+                // index not together with color RGB
+                copyProperty(c, Events.EVENT_COLOR_KEY, e, SaveCalendar.X_COLORINDEX);
+            }
+        }
+
 
         for (Object alarm: e.getAlarms()) {
             VAlarm a = (VAlarm) alarm;

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ProcessVEvent.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ProcessVEvent.java
@@ -467,7 +467,7 @@ public class ProcessVEvent extends RunnableWithProgress {
     }
 
     private Cursor queryEvents(ContentResolver resolver, StringBuilder b, List<String> argsList) {
-        final String where = b.toString();
+        final String where = b.toString() + " AND deleted=0";
         final String[] args = argsList.toArray(new String[argsList.size()]);
         return resolver.query(Events.CONTENT_URI, EVENT_QUERY_COLUMNS, where, args, null);
     }

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
@@ -103,12 +103,23 @@ public class SaveCalendar extends RunnableWithProgress {
     private static final List<String> CLASS_ENUM = Arrays.asList(null, "CONFIDENTIAL", "PRIVATE", "PUBLIC");
     private static final List<String> AVAIL_ENUM = Arrays.asList(null, "FREE", "BUSY-TENTATIVE");
 
+    // calender DB column typically containing creation/last modified time (at least Samsung)
+    private static final String EVENTS_LASTMODIFIED = "secTimeStamp";
+    // iCal property for color (CSS3 color name)
+    private static final String EVENT_COLOR = "COLOR";
+    // X-prefix for my own values
+    private static final String X_PREFIX = "X-CIE-";
+    // color index to CSS color name (matching ~Samsung colors; NextCloud needs them lower case)
+    // 0=lila 9c2760,  1=grün 8bc34a,  2=blau 03a9f4,  3=gelb ffc107,  4=orange ff7043
+    private static final String[] COLOR_NAMES = { "blueviolet", "forestgreen", "deepskyblue", "gold", "coral"};
+
     private static final String[] EVENT_COLS = new String[] {
         Events._ID, Events.ORIGINAL_ID, Events.UID_2445, Events.TITLE, Events.DESCRIPTION,
         Events.ORGANIZER, Events.EVENT_LOCATION, Events.STATUS, Events.ALL_DAY, Events.RDATE,
         Events.RRULE, Events.DTSTART, Events.EVENT_TIMEZONE, Events.DURATION, Events.DTEND,
         Events.EVENT_END_TIMEZONE, Events.ACCESS_LEVEL, Events.AVAILABILITY, Events.EXDATE,
-        Events.EXRULE, Events.CUSTOM_APP_PACKAGE, Events.CUSTOM_APP_URI, Events.HAS_ALARM
+        Events.EXRULE, Events.CUSTOM_APP_PACKAGE, Events.CUSTOM_APP_URI, Events.HAS_ALARM,
+        Events.EVENT_COLOR, Events.EVENT_COLOR_KEY, EVENTS_LASTMODIFIED
     };
 
     private static final String[] REMINDER_COLS = new String[] {
@@ -195,7 +206,7 @@ public class SaveCalendar extends RunnableWithProgress {
         String[] args = new String[] { cal.mIdStr };
         Map<Long, String> newUids = new HashMap<>();
         Cursor cur = resolver.query(Events.CONTENT_URI, cols,
-                Events.CALENDAR_ID + " = ? AND " + Events.UID_2445 + " IS NULL", args, null);
+                Events.CALENDAR_ID + " = ? AND deleted=0 AND " + Events.UID_2445 + " IS NULL", args, null);
         while (cur.moveToNext()) {
             Long id = getLong(cur, Events._ID);
             String uid = activity.generateUid();
@@ -213,7 +224,7 @@ public class SaveCalendar extends RunnableWithProgress {
     }
 
     private List<VEvent> getEvents(ContentResolver resolver, AndroidCalendar cal_src, Calendar cal_dst) {
-        String where = Events.CALENDAR_ID + "=?";
+        String where = Events.CALENDAR_ID + "=? AND deleted=0";
         String[] args = new String[] { cal_src.mIdStr };
         String sortBy = Events.CALENDAR_ID + " ASC";
         Cursor cur;
@@ -230,6 +241,8 @@ public class SaveCalendar extends RunnableWithProgress {
         }
 
         DtStamp timestamp = new DtStamp(); // Same timestamp for all events
+
+        //TW:  _sync_id=1611333603291   pro Event?   oder: secTimeStamp=1611334074922
 
         // Collect up events and add them after any timezones
         setMax(cur.getCount());
@@ -434,6 +447,24 @@ public class SaveCalendar extends RunnableWithProgress {
             copyProperty(l, Property.URL, cur, Events.CUSTOM_APP_URI);
         }
 
+        if (hasStringValue(cur, Events.EVENT_COLOR)) {
+            long argb = getLong(cur, Events.EVENT_COLOR) & 0xffff_ffffL;
+            addProperty(l, X_PREFIX + "COLORARGB", Long.toHexString(argb));
+        }
+        if (hasStringValue(cur, Events.EVENT_COLOR_KEY)) {
+            int ci = getInt(cur, Events.EVENT_COLOR_KEY);
+            addProperty(l, X_PREFIX + "COLORINDEX", Integer.toString(ci));
+            if (ci >= 0  &&  ci < COLOR_NAMES.length) {
+                l.add(new XProperty(EVENT_COLOR, COLOR_NAMES[ci]));
+            }
+        }
+
+        if (hasStringValue(cur, EVENTS_LASTMODIFIED)) {
+            DateTime lastMod = new DateTime(true);          // must be UTC
+            lastMod.setTime(getLong(cur, EVENTS_LASTMODIFIED));
+            addProperty(l, Property.LAST_MODIFIED, lastMod.toString());
+        }
+
         VEvent e = new VEvent(l);
 
         if (getInt(cur, Events.HAS_ALARM) == 1) {
@@ -545,19 +576,23 @@ public class SaveCalendar extends RunnableWithProgress {
         return dt;
     }
 
-    private String copyProperty(PropertyList l, String evName, Cursor cur, String dbName) {
+    private void addProperty(PropertyList l, String evName, String value) {
         // None of the exceptions caught below should be able to be thrown AFAICS.
         try {
-            String value = getString(cur, dbName);
             if (value != null) {
                 Property p = mPropertyFactory.createProperty(evName);
                 p.setValue(value);
                 l.add(p);
-                return value;
             }
         } catch (IOException | URISyntaxException | ParseException ignored) {
+            Log.d(TAG, "Ignore property: " + evName + "=" + value + ": " + ignored.toString());
         }
-        return null;
+    }
+
+    private String copyProperty(PropertyList l, String evName, Cursor cur, String dbName) {
+        String value = getString(cur, dbName);
+        addProperty(l, evName, value);
+        return value;
     }
 
     private void copyEnumProperty(PropertyList l, String evName, Cursor cur, String dbName,
@@ -574,6 +609,7 @@ public class SaveCalendar extends RunnableWithProgress {
                 }
             }
         } catch (IOException | URISyntaxException | ParseException ignored) {
+            Log.d(TAG, "Ignore enum-property: " + evName + "=" + dbName + ": " + ignored.toString());
         }
     }
 }

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
@@ -88,7 +88,9 @@ public class MainActivity extends FragmentActivity implements View.OnClickListen
     private static final String[] MY_PERMISSIONS = new String[] {
         Manifest.permission.GET_ACCOUNTS,
         Manifest.permission.READ_CALENDAR,
-        Manifest.permission.READ_EXTERNAL_STORAGE
+        Manifest.permission.WRITE_CALENDAR,
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
     private Settings mSettings;

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/util/ColorUtils.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/util/ColorUtils.java
@@ -1,0 +1,242 @@
+package org.sufficientlysecure.ical.util;
+
+import java.util.ArrayList;
+
+/**
+ * Java Code to get a color name from rgb/hex value/awt color
+ *
+ * Bases on:  https://gist.github.com/XiaoxiaoLi/8031146#file-colorutils-java
+ */
+public class ColorUtils {
+
+    private static final ArrayList<ColorName> colorList = new ArrayList<>(256);
+
+    static {
+        colorList.add(new ColorName("AliceBlue", 0xF0, 0xF8, 0xFF));
+        colorList.add(new ColorName("AntiqueWhite", 0xFA, 0xEB, 0xD7));
+        colorList.add(new ColorName("Aqua", 0x00, 0xFF, 0xFF));
+        colorList.add(new ColorName("Aquamarine", 0x7F, 0xFF, 0xD4));
+        colorList.add(new ColorName("Azure", 0xF0, 0xFF, 0xFF));
+        colorList.add(new ColorName("Beige", 0xF5, 0xF5, 0xDC));
+        colorList.add(new ColorName("Bisque", 0xFF, 0xE4, 0xC4));
+        colorList.add(new ColorName("Black", 0x00, 0x00, 0x00));
+        colorList.add(new ColorName("BlanchedAlmond", 0xFF, 0xEB, 0xCD));
+        colorList.add(new ColorName("Blue", 0x00, 0x00, 0xFF));
+        colorList.add(new ColorName("BlueViolet", 0x8A, 0x2B, 0xE2));
+        colorList.add(new ColorName("Brown", 0xA5, 0x2A, 0x2A));
+        colorList.add(new ColorName("BurlyWood", 0xDE, 0xB8, 0x87));
+        colorList.add(new ColorName("CadetBlue", 0x5F, 0x9E, 0xA0));
+        colorList.add(new ColorName("Chartreuse", 0x7F, 0xFF, 0x00));
+        colorList.add(new ColorName("Chocolate", 0xD2, 0x69, 0x1E));
+        colorList.add(new ColorName("Coral", 0xFF, 0x7F, 0x50));
+        colorList.add(new ColorName("CornflowerBlue", 0x64, 0x95, 0xED));
+        colorList.add(new ColorName("Cornsilk", 0xFF, 0xF8, 0xDC));
+        colorList.add(new ColorName("Crimson", 0xDC, 0x14, 0x3C));
+        colorList.add(new ColorName("Cyan", 0x00, 0xFF, 0xFF));
+        colorList.add(new ColorName("DarkBlue", 0x00, 0x00, 0x8B));
+        colorList.add(new ColorName("DarkCyan", 0x00, 0x8B, 0x8B));
+        colorList.add(new ColorName("DarkGoldenRod", 0xB8, 0x86, 0x0B));
+        colorList.add(new ColorName("DarkGray", 0xA9, 0xA9, 0xA9));
+        colorList.add(new ColorName("DarkGreen", 0x00, 0x64, 0x00));
+        colorList.add(new ColorName("DarkKhaki", 0xBD, 0xB7, 0x6B));
+        colorList.add(new ColorName("DarkMagenta", 0x8B, 0x00, 0x8B));
+        colorList.add(new ColorName("DarkOliveGreen", 0x55, 0x6B, 0x2F));
+        colorList.add(new ColorName("DarkOrange", 0xFF, 0x8C, 0x00));
+        colorList.add(new ColorName("DarkOrchid", 0x99, 0x32, 0xCC));
+        colorList.add(new ColorName("DarkRed", 0x8B, 0x00, 0x00));
+        colorList.add(new ColorName("DarkSalmon", 0xE9, 0x96, 0x7A));
+        colorList.add(new ColorName("DarkSeaGreen", 0x8F, 0xBC, 0x8F));
+        colorList.add(new ColorName("DarkSlateBlue", 0x48, 0x3D, 0x8B));
+        colorList.add(new ColorName("DarkSlateGray", 0x2F, 0x4F, 0x4F));
+        colorList.add(new ColorName("DarkTurquoise", 0x00, 0xCE, 0xD1));
+        colorList.add(new ColorName("DarkViolet", 0x94, 0x00, 0xD3));
+        colorList.add(new ColorName("DeepPink", 0xFF, 0x14, 0x93));
+        colorList.add(new ColorName("DeepSkyBlue", 0x00, 0xBF, 0xFF));
+        colorList.add(new ColorName("DimGray", 0x69, 0x69, 0x69));
+        colorList.add(new ColorName("DodgerBlue", 0x1E, 0x90, 0xFF));
+        colorList.add(new ColorName("FireBrick", 0xB2, 0x22, 0x22));
+        colorList.add(new ColorName("FloralWhite", 0xFF, 0xFA, 0xF0));
+        colorList.add(new ColorName("ForestGreen", 0x22, 0x8B, 0x22));
+        colorList.add(new ColorName("Fuchsia", 0xFF, 0x00, 0xFF));
+        colorList.add(new ColorName("Gainsboro", 0xDC, 0xDC, 0xDC));
+        colorList.add(new ColorName("GhostWhite", 0xF8, 0xF8, 0xFF));
+        colorList.add(new ColorName("Gold", 0xFF, 0xD7, 0x00));
+        colorList.add(new ColorName("GoldenRod", 0xDA, 0xA5, 0x20));
+        colorList.add(new ColorName("Gray", 0x80, 0x80, 0x80));
+        colorList.add(new ColorName("Green", 0x00, 0x80, 0x00));
+        colorList.add(new ColorName("GreenYellow", 0xAD, 0xFF, 0x2F));
+        colorList.add(new ColorName("HoneyDew", 0xF0, 0xFF, 0xF0));
+        colorList.add(new ColorName("HotPink", 0xFF, 0x69, 0xB4));
+        colorList.add(new ColorName("IndianRed", 0xCD, 0x5C, 0x5C));
+        colorList.add(new ColorName("Indigo", 0x4B, 0x00, 0x82));
+        colorList.add(new ColorName("Ivory", 0xFF, 0xFF, 0xF0));
+        colorList.add(new ColorName("Khaki", 0xF0, 0xE6, 0x8C));
+        colorList.add(new ColorName("Lavender", 0xE6, 0xE6, 0xFA));
+        colorList.add(new ColorName("LavenderBlush", 0xFF, 0xF0, 0xF5));
+        colorList.add(new ColorName("LawnGreen", 0x7C, 0xFC, 0x00));
+        colorList.add(new ColorName("LemonChiffon", 0xFF, 0xFA, 0xCD));
+        colorList.add(new ColorName("LightBlue", 0xAD, 0xD8, 0xE6));
+        colorList.add(new ColorName("LightCoral", 0xF0, 0x80, 0x80));
+        colorList.add(new ColorName("LightCyan", 0xE0, 0xFF, 0xFF));
+        colorList.add(new ColorName("LightGoldenRodYellow", 0xFA, 0xFA, 0xD2));
+        colorList.add(new ColorName("LightGray", 0xD3, 0xD3, 0xD3));
+        colorList.add(new ColorName("LightGreen", 0x90, 0xEE, 0x90));
+        colorList.add(new ColorName("LightPink", 0xFF, 0xB6, 0xC1));
+        colorList.add(new ColorName("LightSalmon", 0xFF, 0xA0, 0x7A));
+        colorList.add(new ColorName("LightSeaGreen", 0x20, 0xB2, 0xAA));
+        colorList.add(new ColorName("LightSkyBlue", 0x87, 0xCE, 0xFA));
+        colorList.add(new ColorName("LightSlateGray", 0x77, 0x88, 0x99));
+        colorList.add(new ColorName("LightSteelBlue", 0xB0, 0xC4, 0xDE));
+        colorList.add(new ColorName("LightYellow", 0xFF, 0xFF, 0xE0));
+        colorList.add(new ColorName("Lime", 0x00, 0xFF, 0x00));
+        colorList.add(new ColorName("LimeGreen", 0x32, 0xCD, 0x32));
+        colorList.add(new ColorName("Linen", 0xFA, 0xF0, 0xE6));
+        colorList.add(new ColorName("Magenta", 0xFF, 0x00, 0xFF));
+        colorList.add(new ColorName("Maroon", 0x80, 0x00, 0x00));
+        colorList.add(new ColorName("MediumAquaMarine", 0x66, 0xCD, 0xAA));
+        colorList.add(new ColorName("MediumBlue", 0x00, 0x00, 0xCD));
+        colorList.add(new ColorName("MediumOrchid", 0xBA, 0x55, 0xD3));
+        colorList.add(new ColorName("MediumPurple", 0x93, 0x70, 0xDB));
+        colorList.add(new ColorName("MediumSeaGreen", 0x3C, 0xB3, 0x71));
+        colorList.add(new ColorName("MediumSlateBlue", 0x7B, 0x68, 0xEE));
+        colorList.add(new ColorName("MediumSpringGreen", 0x00, 0xFA, 0x9A));
+        colorList.add(new ColorName("MediumTurquoise", 0x48, 0xD1, 0xCC));
+        colorList.add(new ColorName("MediumVioletRed", 0xC7, 0x15, 0x85));
+        colorList.add(new ColorName("MidnightBlue", 0x19, 0x19, 0x70));
+        colorList.add(new ColorName("MintCream", 0xF5, 0xFF, 0xFA));
+        colorList.add(new ColorName("MistyRose", 0xFF, 0xE4, 0xE1));
+        colorList.add(new ColorName("Moccasin", 0xFF, 0xE4, 0xB5));
+        colorList.add(new ColorName("NavajoWhite", 0xFF, 0xDE, 0xAD));
+        colorList.add(new ColorName("Navy", 0x00, 0x00, 0x80));
+        colorList.add(new ColorName("OldLace", 0xFD, 0xF5, 0xE6));
+        colorList.add(new ColorName("Olive", 0x80, 0x80, 0x00));
+        colorList.add(new ColorName("OliveDrab", 0x6B, 0x8E, 0x23));
+        colorList.add(new ColorName("Orange", 0xFF, 0xA5, 0x00));
+        colorList.add(new ColorName("OrangeRed", 0xFF, 0x45, 0x00));
+        colorList.add(new ColorName("Orchid", 0xDA, 0x70, 0xD6));
+        colorList.add(new ColorName("PaleGoldenRod", 0xEE, 0xE8, 0xAA));
+        colorList.add(new ColorName("PaleGreen", 0x98, 0xFB, 0x98));
+        colorList.add(new ColorName("PaleTurquoise", 0xAF, 0xEE, 0xEE));
+        colorList.add(new ColorName("PaleVioletRed", 0xDB, 0x70, 0x93));
+        colorList.add(new ColorName("PapayaWhip", 0xFF, 0xEF, 0xD5));
+        colorList.add(new ColorName("PeachPuff", 0xFF, 0xDA, 0xB9));
+        colorList.add(new ColorName("Peru", 0xCD, 0x85, 0x3F));
+        colorList.add(new ColorName("Pink", 0xFF, 0xC0, 0xCB));
+        colorList.add(new ColorName("Plum", 0xDD, 0xA0, 0xDD));
+        colorList.add(new ColorName("PowderBlue", 0xB0, 0xE0, 0xE6));
+        colorList.add(new ColorName("Purple", 0x80, 0x00, 0x80));
+        colorList.add(new ColorName("Red", 0xFF, 0x00, 0x00));
+        colorList.add(new ColorName("RosyBrown", 0xBC, 0x8F, 0x8F));
+        colorList.add(new ColorName("RoyalBlue", 0x41, 0x69, 0xE1));
+        colorList.add(new ColorName("SaddleBrown", 0x8B, 0x45, 0x13));
+        colorList.add(new ColorName("Salmon", 0xFA, 0x80, 0x72));
+        colorList.add(new ColorName("SandyBrown", 0xF4, 0xA4, 0x60));
+        colorList.add(new ColorName("SeaGreen", 0x2E, 0x8B, 0x57));
+        colorList.add(new ColorName("SeaShell", 0xFF, 0xF5, 0xEE));
+        colorList.add(new ColorName("Sienna", 0xA0, 0x52, 0x2D));
+        colorList.add(new ColorName("Silver", 0xC0, 0xC0, 0xC0));
+        colorList.add(new ColorName("SkyBlue", 0x87, 0xCE, 0xEB));
+        colorList.add(new ColorName("SlateBlue", 0x6A, 0x5A, 0xCD));
+        colorList.add(new ColorName("SlateGray", 0x70, 0x80, 0x90));
+        colorList.add(new ColorName("Snow", 0xFF, 0xFA, 0xFA));
+        colorList.add(new ColorName("SpringGreen", 0x00, 0xFF, 0x7F));
+        colorList.add(new ColorName("SteelBlue", 0x46, 0x82, 0xB4));
+        colorList.add(new ColorName("Tan", 0xD2, 0xB4, 0x8C));
+        colorList.add(new ColorName("Teal", 0x00, 0x80, 0x80));
+        colorList.add(new ColorName("Thistle", 0xD8, 0xBF, 0xD8));
+        colorList.add(new ColorName("Tomato", 0xFF, 0x63, 0x47));
+        colorList.add(new ColorName("Turquoise", 0x40, 0xE0, 0xD0));
+        colorList.add(new ColorName("Violet", 0xEE, 0x82, 0xEE));
+        colorList.add(new ColorName("Wheat", 0xF5, 0xDE, 0xB3));
+        colorList.add(new ColorName("White", 0xFF, 0xFF, 0xFF));
+        colorList.add(new ColorName("WhiteSmoke", 0xF5, 0xF5, 0xF5));
+        colorList.add(new ColorName("Yellow", 0xFF, 0xFF, 0x00));
+        colorList.add(new ColorName("YellowGreen", 0x9A, 0xCD, 0x32));
+    }
+
+    /**
+     * Get the closest color name from our list
+     */
+    public static String getColorNameFromRgb(int r, int g, int b) {
+        ColorName closestMatch = null;
+        int minMSE = Integer.MAX_VALUE;
+        int mse;
+        for (ColorName c : colorList) {
+            mse = c.computeMSE(r, g, b);
+            if (mse < minMSE) {
+                minMSE = mse;
+                closestMatch = c;
+            }
+        }
+
+        if (closestMatch != null) {
+            return closestMatch.getName();
+        } else {
+            return "";      // will never happen
+        }
+    }
+
+    /**
+     * Convert hexColor to rgb, then call getColorNameFromRgb(r, g, b)
+     */
+    public static String getColorNameFromHex(int hexColor) {
+        int r = (hexColor & 0xFF0000) >> 16;
+        int g = (hexColor & 0xFF00) >> 8;
+        int b = (hexColor & 0xFF);
+        return getColorNameFromRgb(r, g, b);
+    }
+
+
+    public static ColorName getColorFromName(String colorName) {
+        // XXX using a map would be better, but case-insensitivity must be dealt with!
+        if (colorName != null) {
+            for (ColorName cn : colorList) {
+                if (cn.getName().equalsIgnoreCase(colorName)) {
+                    return cn;
+                }
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     * SubClass of ColorUtils. In order to lookup color name
+     */
+    public static class ColorName {
+        private final int r, g, b;
+        private final String name;
+
+        public ColorName(String name, int r, int g, int b) {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+            this.name = name;
+        }
+
+        public int computeMSE(int pixR, int pixG, int pixB) {
+            return (int) ( ((pixR - r) * (pixR - r) + (pixG - g) * (pixG - g)
+                    + (pixB - b) * (pixB - b)) / 3);
+        }
+
+        public int getR() {
+            return r;
+        }
+
+        public int getG() {
+            return g;
+        }
+
+        public int getB() {
+            return b;
+        }
+
+        public int getRGB() {
+            return (r << 16) + (g << 8) + b;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/CalendarImportExport/src/main/res/values/legal.xml
+++ b/CalendarImportExport/src/main/res/values/legal.xml
@@ -6,6 +6,8 @@
 <body>
 <p><b><h1>Calendar Import/Export</h1></b></p>
 
+<p>With some changes/additions 2021 by Thies Wellpott - no warrenty, use completely on your own risk.</p>
+
 <p><tt>Copyright &#169; 2015 Jon Griffiths<br>
 Copyright &#169; 2013 Dominik Schürmann<br>
 Copyright &#169; 2010, 2011 Lukas Aichbauer</tt></p>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 20 19:51:47 CEST 2019
+#Fri Jan 22 18:25:34 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
In local calenders a deleted event just gets "deleted=1" set, the vent is not removed from the database/calendar provider (see also issue #44). This upddate filters this by adding "deleted=0" to the export-queries.

Additionally the color of events is supported on export and import. The iCal property "COLOR" (RFC-7986) is used (CSS3 color name), additionally two "X-CIE-" properties (own addition with CIE = CalenderImportExport) with the full value from calendar db (ARGB value and color index). As CSS3 color name the best matching one is used (see new file ColorUtils.java).

I tested it with NextCloud, DAVx5 (you have to explicitly activate event color sync in the account settings!), on a Samsung A3 and a Pixel 4a, the internal calendar app, aCalendar+, and Etar.

Also the android SDK versions in gradle build have been updated.

For anyone needing this functionality right now, I offer the compiled APK with these changes:  
https://it-tw.de/android/CalendarImportExport-v27tw.apk
(I added no malicious code, but use on your own risk anyway; the APK is signed with a not listed signature at Google Play, so you'll get a warning; you will need to uninstall the previous "official" version first, because of a signature change).
_Note: I found out, that my compiled APK crashes on the import on Android 11, but already during filling the importable files in the drop-down. It works under Android 8 or when executing the debug-build (so undebugable error, great!). I did not change any code for this, so this seems to be an android-target-sdk related problem._