### PR TITLE
Fix export crashes in Android 9

### DIFF
--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
@@ -231,11 +231,14 @@ public class SaveCalendar extends RunnableWithProgress {
         String where = Events.CALENDAR_ID + "=? AND deleted=0";
         String[] args = new String[] { cal_src.mIdStr };
         String sortBy = Events.CALENDAR_ID + " ASC";
-        Cursor cur;
+        Cursor cur = null;
+
         try {
             cur = resolver.query(Events.CONTENT_URI, mAllCols ? null : EVENT_COLS,
                                  where, args, sortBy);
-        } catch (Exception except) {
+        } catch (Exception ignored) {}
+
+        if(cur == null) {
             Log.w(TAG, "Calendar provider is missing columns, continuing anyway");
             int n = 0;
             for (n = 0; n < EVENT_COLS.length; ++n)

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
@@ -355,6 +355,7 @@ public class MainActivity extends FragmentActivity implements View.OnClickListen
         boolean found = false;
         for (int i = 0; i < mCalendars.size(); i++) {
             if (mCalendars.get(i).mId == mIntentCalendarId &&
+                mCalendars.get(i).mName != null &&
                 (calendarName == null || mCalendars.get(i).mName.contentEquals(calendarName))) {
                 found = true;
                 final int index = i;


### PR DESCRIPTION
This fixes the following crashes in Android 9 (honor 9 lite):

Startup crash due to null `mCalendars.get(i).mName`:
```
2022-05-14 19:16:40.330 16853-16960/org.sufficientlysecure.ical E/AndroidRuntime: FATAL EXCEPTION: Thread-3
    Process: org.sufficientlysecure.ical, PID: 16853
    java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.contentEquals(java.lang.CharSequence)' on a null object reference
        at org.sufficientlysecure.ical.ui.MainActivity.initialiseCalendars(MainActivity.java:359)
        at org.sufficientlysecure.ical.ui.MainActivity.access$1500(MainActivity.java:81)
        at org.sufficientlysecure.ical.ui.MainActivity$9.run(MainActivity.java:442)
        at java.lang.Thread.run(Thread.java:784)
2022-05-14 19:16:40.355 16853-16960/org.sufficientlysecure.ical I/Process: Sending signal. PID: 16853 SIG: 9
```

Export crash due to null cursor returned due to unsupported columns:
```
2022-05-14 19:18:25.015 17114-17181/org.sufficientlysecure.ical E/ICS_RunnableWithProgress: An exception occurred
    java.lang.NullPointerException: Attempt to invoke interface method 'int android.database.Cursor.getCount()' on a null object reference
        at org.sufficientlysecure.ical.SaveCalendar.getEvents(SaveCalendar.java:255)
        at org.sufficientlysecure.ical.SaveCalendar.run(SaveCalendar.java:193)
        at org.sufficientlysecure.ical.ui.dialogs.RunnableWithProgress$1.run(RunnableWithProgress.java:44)
        at java.lang.Thread.run(Thread.java:784)
```

Export working correctly after the fixes